### PR TITLE
DatabaseTestValue

### DIFF
--- a/Sources/SafeFetching/Predicate/DatabaseTestValue.swift
+++ b/Sources/SafeFetching/Predicate/DatabaseTestValue.swift
@@ -10,7 +10,7 @@ public protocol DatabaseTestValue {
 
 extension String: DatabaseTestValue {
 
-    public var testValue: String { self }
+    public var testValue: String { #""\#(self)""# }
 }
 
 extension Int: DatabaseTestValue {
@@ -64,4 +64,11 @@ extension Array: DatabaseTestValue where Element: DatabaseTestValue {
 extension DatabaseTestValue where Self: RawRepresentable, RawValue: DatabaseValue {
 
     public var testValue: String { String(describing: rawValue) }
+}
+
+extension ClosedRange: DatabaseTestValue where Bound: Numeric {
+
+    public var testValue: String {
+        "{\(lowerBound), \(upperBound)}"
+    }
 }

--- a/Sources/SafeFetching/Predicate/DatabaseTestValue.swift
+++ b/Sources/SafeFetching/Predicate/DatabaseTestValue.swift
@@ -1,0 +1,67 @@
+//
+// SafeFetching
+// Copyright © 2021-present Alexis Bridoux.
+// MIT license, see LICENSE file for details
+
+public protocol DatabaseTestValue {
+
+    var testValue: String { get }
+}
+
+extension String: DatabaseTestValue {
+
+    public var testValue: String { self }
+}
+
+extension Int: DatabaseTestValue {
+
+    public var testValue: String { String(describing: self) }
+}
+
+extension Int16: DatabaseTestValue {
+
+    public var testValue: String { String(describing: self) }
+}
+
+extension Int32: DatabaseTestValue {
+
+    public var testValue: String { String(describing: self) }
+}
+
+extension Int64: DatabaseTestValue {
+
+    public var testValue: String { String(describing: self) }
+}
+
+extension Double: DatabaseTestValue {
+
+    public var testValue: String { String(describing: self) }
+}
+
+extension Float: DatabaseTestValue {
+
+    public var testValue: String { String(describing: self) }
+}
+
+extension Optional: DatabaseTestValue where Wrapped: DatabaseTestValue {
+
+    public var testValue: String {
+        switch self {
+        case .none: return "nil"
+        case .some(let wrapped):
+            return wrapped.testValue
+        }
+    }
+}
+
+extension Array: DatabaseTestValue where Element: DatabaseTestValue {
+
+    public var testValue: String {
+        "{ \(map(\.testValue).joined(separator: ","))}"
+    }
+}
+
+extension DatabaseTestValue where Self: RawRepresentable, RawValue: DatabaseValue {
+
+    public var testValue: String { String(describing: rawValue) }
+}

--- a/Sources/SafeFetching/Predicate/DatabaseTestValue.swift
+++ b/Sources/SafeFetching/Predicate/DatabaseTestValue.swift
@@ -3,8 +3,10 @@
 // Copyright © 2021-present Alexis Bridoux.
 // MIT license, see LICENSE file for details
 
+/// A type that can be used in a predicate as a test value
 public protocol DatabaseTestValue {
 
+    /// Formatted string value that can be used in the format of a `NSPredicate`
     var testValue: String { get }
 }
 

--- a/Sources/SafeFetching/Predicate/DatabaseValue.swift
+++ b/Sources/SafeFetching/Predicate/DatabaseValue.swift
@@ -11,7 +11,7 @@ public struct DatabaseValueIdentification {
     init() {}
 }
 
-/// A value that can be used in a predicate when fetching a CoreData store
+/// A type that can be used for an attribute in a predicate when fetching a CoreData store
 ///
 /// Used to constraint some fetch functions to use only a valid storable type
 public protocol DatabaseValue {

--- a/Sources/SafeFetching/Predicate/DatabaseValue.swift
+++ b/Sources/SafeFetching/Predicate/DatabaseValue.swift
@@ -4,9 +4,10 @@
 // MIT license, see LICENSE file for details
 
 import Foundation
+import CoreData
 
 /// Stub type with internal init to ensure no conformance to ``DatabaseValue`` can be added outside of the package
-public struct DatabaseValueIdentification<T> {
+public struct DatabaseValueIdentification {
     init() {}
 }
 
@@ -15,59 +16,79 @@ public struct DatabaseValueIdentification<T> {
 /// Used to constraint some fetch functions to use only a valid storable type
 public protocol DatabaseValue {
 
-    static var identification: DatabaseValueIdentification<Self> { get }
+    static var identification: DatabaseValueIdentification { get }
 }
 
+// MARK: Field
+
 extension String: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<String>()
+    public static let identification = DatabaseValueIdentification()
 }
 
 extension Int: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<Int>()
+    public static let identification = DatabaseValueIdentification()
 }
 
 extension Int16: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<Int16>()
+    public static let identification = DatabaseValueIdentification()
 }
 
 extension Int32: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<Int32>()
+    public static let identification = DatabaseValueIdentification()
 }
 
 extension Int64: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<Int64>()
+    public static let identification = DatabaseValueIdentification()
 }
 
 extension Float: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<Float>()
+    public static let identification = DatabaseValueIdentification()
 }
 
 extension Double: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<Double>()
+    public static let identification = DatabaseValueIdentification()
 }
 
 extension Bool: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<Bool>()
+    public static let identification = DatabaseValueIdentification()
 }
 
 extension Date: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<Date>()
+    public static let identification = DatabaseValueIdentification()
 }
 
 extension Data: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<Data>()
+    public static let identification = DatabaseValueIdentification()
 }
 
 extension UUID: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<UUID>()
+    public static let identification = DatabaseValueIdentification()
 }
 
 extension URL: DatabaseValue {
-    public static var identification = DatabaseValueIdentification<URL>()
+    public static let identification = DatabaseValueIdentification()
 }
 
+// MARK:  Relationship
+
+extension Set: DatabaseValue where Element: NSManagedObject {
+    public static var identification: DatabaseValueIdentification {
+        DatabaseValueIdentification()
+    }
+}
+
+extension NSSet: DatabaseValue {
+    public static let identification = DatabaseValueIdentification()
+}
+
+extension NSOrderedSet: DatabaseValue {
+    public static let identification = DatabaseValueIdentification()
+}
+
+// MARK: Optional
+
 extension Optional: DatabaseValue where Wrapped: DatabaseValue {
-    public static var identification: DatabaseValueIdentification<Wrapped?> {
-        DatabaseValueIdentification<Wrapped?>()
+    public static var identification: DatabaseValueIdentification {
+        DatabaseValueIdentification()
     }
 }

--- a/Sources/SafeFetching/Predicate/Declarations/BooleanKeyPathPredicate+Comparison.swift
+++ b/Sources/SafeFetching/Predicate/Declarations/BooleanKeyPathPredicate+Comparison.swift
@@ -5,27 +5,26 @@
 
 import CoreData
 
-public func == <E: NSManagedObject, V: Equatable & DatabaseValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
+public func == <E: NSManagedObject, V: Equatable & DatabaseValue & DatabaseTestValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
     .init(keyPath: lhs, operatorString: "==", value: rhs)
 }
 
-public func != <E: NSManagedObject, V: Equatable & DatabaseValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
+public func != <E: NSManagedObject, V: Equatable & DatabaseValue & DatabaseTestValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
     .init(keyPath: lhs, operatorString: "!=", value: rhs)
 }
 
-public func > <E: NSManagedObject, V: Comparable & DatabaseValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
+public func > <E: NSManagedObject, V: Comparable & DatabaseValue & DatabaseTestValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
     .init(keyPath: lhs, operatorString: ">", value: rhs)
 }
 
-public func >= <E: NSManagedObject, V: Comparable & DatabaseValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
+public func >= <E: NSManagedObject, V: Comparable & DatabaseValue & DatabaseTestValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
     .init(keyPath: lhs, operatorString: ">=", value: rhs)
 }
 
-public func < <E: NSManagedObject, V: Comparable & DatabaseValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
+public func < <E: NSManagedObject, V: Comparable & DatabaseValue & DatabaseTestValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
     .init(keyPath: lhs, operatorString: "<", value: rhs)
 }
 
-public func <= <E: NSManagedObject, V: Comparable & DatabaseValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
+public func <= <E: NSManagedObject, V: Comparable & DatabaseValue & DatabaseTestValue>(lhs: KeyPath<E, V>, rhs: V) -> Builders.Predicate<E> {
     .init(keyPath: lhs, operatorString: "<=", value: rhs)
 }
-

--- a/Sources/SafeFetching/Predicate/Declarations/BooleanStringKeyPathPredicate+Comparison.swift
+++ b/Sources/SafeFetching/Predicate/Declarations/BooleanStringKeyPathPredicate+Comparison.swift
@@ -7,88 +7,44 @@ import CoreData
 
 // MARK: - DatabaseValue
 
-public func == <E: NSManagedObject, V: DatabaseValue & Equatable>(
+public func == <E: NSManagedObject, V: Equatable & DatabaseTestValue>(
     lhs: StringKeyPath<E, V>,
     rhs: V
 ) -> Builders.Predicate<E> {
     .init(keyPathString: lhs.key, operatorString: "==", value: rhs)
 }
 
-public func != <E: NSManagedObject, V: DatabaseValue & Equatable>(
+public func != <E: NSManagedObject, V: Equatable & DatabaseTestValue>(
     lhs: StringKeyPath<E, V>,
     rhs: V
 ) -> Builders.Predicate<E> {
     .init(keyPathString: lhs.key, operatorString: "!=", value: rhs)
 }
 
-public func > <E: NSManagedObject, V: DatabaseValue & Comparable>(
+public func > <E: NSManagedObject, V: Comparable & DatabaseTestValue>(
     lhs: StringKeyPath<E, V>,
     rhs: V
 ) -> Builders.Predicate<E> {
     .init(keyPathString: lhs.key, operatorString: ">", value: rhs)
 }
 
-public func >= <E: NSManagedObject, V: DatabaseValue & Comparable>(
+public func >= <E: NSManagedObject, V: Comparable & DatabaseTestValue>(
     lhs: StringKeyPath<E, V>,
     rhs: V
 ) -> Builders.Predicate<E> {
     .init(keyPathString: lhs.key, operatorString: ">=", value: rhs)
 }
 
-public func < <E: NSManagedObject, V: DatabaseValue & Comparable>(
+public func < <E: NSManagedObject, V: Comparable & DatabaseTestValue>(
     lhs: StringKeyPath<E, V>,
     rhs: V
 ) -> Builders.Predicate<E>{
     .init(keyPathString: lhs.key, operatorString: "<", value: rhs)
 }
 
-public func <= <E: NSManagedObject, V: DatabaseValue & Comparable>(
+public func <= <E: NSManagedObject, V: Comparable & DatabaseTestValue>(
     lhs: StringKeyPath<E, V>,
     rhs: V
 ) -> Builders.Predicate<E> {
     .init(keyPathString: lhs.key, operatorString: "<=", value: rhs)
-}
-
-// MARK: - RawRepresentable
-
-public func == <E: NSManagedObject, V: RawRepresentable & Equatable>(
-    lhs: StringKeyPath<E, V>,
-    rhs: V
-) -> Builders.Predicate<E> {
-    .init(keyPathString: lhs.key, operatorString: "==", value: rhs.rawValue)
-}
-
-public func != <E: NSManagedObject, V: RawRepresentable & Equatable>(
-    lhs: StringKeyPath<E, V>,
-    rhs: V
-) -> Builders.Predicate<E> {
-    .init(keyPathString: lhs.key, operatorString: "!=", value: rhs.rawValue)
-}
-
-public func > <E: NSManagedObject, V: RawRepresentable & Comparable>(
-    lhs: StringKeyPath<E, V>,
-    rhs: V
-) -> Builders.Predicate<E> {
-    .init(keyPathString: lhs.key, operatorString: ">", value: rhs.rawValue)
-}
-
-public func >= <E: NSManagedObject, V: RawRepresentable & Comparable>(
-    lhs: StringKeyPath<E, V>,
-    rhs: V
-) -> Builders.Predicate<E> {
-    .init(keyPathString: lhs.key, operatorString: ">=", value: rhs.rawValue)
-}
-
-public func < <E: NSManagedObject, V: RawRepresentable & Comparable>(
-    lhs: StringKeyPath<E, V>,
-    rhs: V
-) -> Builders.Predicate<E>{
-    .init(keyPathString: lhs.key, operatorString: "<", value: rhs.rawValue)
-}
-
-public func <= <E: NSManagedObject, V: RawRepresentable & Comparable>(
-    lhs: StringKeyPath<E, V>,
-    rhs: V
-) -> Builders.Predicate<E> {
-    .init(keyPathString: lhs.key, operatorString: "<=", value: rhs.rawValue)
 }

--- a/Sources/SafeFetching/Predicate/Declarations/PredicateRightValue+Range.swift
+++ b/Sources/SafeFetching/Predicate/Declarations/PredicateRightValue+Range.swift
@@ -3,7 +3,7 @@
 // Copyright © 2021-present Alexis Bridoux.
 // MIT license, see LICENSE file for details
 
-public extension Builders.KeyPathPredicateRightValue where Value: Numeric & Comparable & DatabaseValue {
+public extension Builders.KeyPathPredicateRightValue where Value: Numeric & Comparable & DatabaseValue & DatabaseTestValue { 
 
     static func isIn(_ range: ClosedRange<Value>) -> Builders.KeyPathPredicateRightValue<Entity, Value, [Value]> {
         .init { .init(keyPath: $0, operatorString: "BETWEEN", value: [range.lowerBound, range.upperBound]) }

--- a/Sources/SafeFetching/Predicate/Declarations/PredicateRightValue+Range.swift
+++ b/Sources/SafeFetching/Predicate/Declarations/PredicateRightValue+Range.swift
@@ -6,24 +6,26 @@
 public extension Builders.KeyPathPredicateRightValue where Value: Numeric & Comparable & DatabaseValue & DatabaseTestValue { 
 
     static func isIn(_ range: ClosedRange<Value>) -> Builders.KeyPathPredicateRightValue<Entity, Value, [Value]> {
-        .init { .init(keyPath: $0, operatorString: "BETWEEN", value: [range.lowerBound, range.upperBound]) }
+        .init { keyPath in
+            .init(keyPath: keyPath, operatorString: "BETWEEN", value: range)
+        }
     }
 
     static func isNotIn(_ range: ClosedRange<Value>) -> Builders.KeyPathPredicateRightValue<Entity, Value, [Value]> {
-        .init { .init(keyPath: $0, operatorString: "BETWEEN", value: [range.lowerBound, range.upperBound], isInverted: true) }
+        .init { keyPath in
+            .init(keyPath: keyPath , operatorString: "BETWEEN", value: range, isInverted: true)
+        }
     }
 
     static func isIn(_ range: Range<Value>) -> Builders.KeyPathPredicateRightValue<Entity, Value, [Value]> {
-        .init {
-            .init(keyPath: $0, value: [range.lowerBound, range.upperBound]) { "%@ <= \($0) AND \($0) < %@" }
-                argumentsOrder: { [range.lowerBound, $0, $0, range.upperBound] }
+        .init { keyPath in
+            .init(keyPath: keyPath) { "\(range.lowerBound) <= \($0) AND \($0) < \(range.upperBound)" }
         }
     }
 
     static func isNotIn(_ range: Range<Value>) -> Builders.KeyPathPredicateRightValue<Entity, Value, [Value]> {
-        .init {
-            .init(keyPath: $0, value: [range.lowerBound, range.upperBound]) { "%@ > \($0) OR \($0) >= %@" }
-                argumentsOrder: { [range.lowerBound, $0, $0, range.upperBound] }
+        .init { keyPath in
+            .init(keyPath: keyPath, isInverted: true) { "\($0) < \(range.lowerBound) OR \($0) >= \(range.upperBound)" }
         }
     }
 }

--- a/Sources/SafeFetching/Predicate/Declarations/PredicateRightValue+ValuesSet.swift
+++ b/Sources/SafeFetching/Predicate/Declarations/PredicateRightValue+ValuesSet.swift
@@ -3,7 +3,7 @@
 // Copyright © 2021-present Alexis Bridoux.
 // MIT license, see LICENSE file for details
 
-public extension Builders.KeyPathPredicateRightValue where Value: Equatable & DatabaseValue {
+public extension Builders.KeyPathPredicateRightValue where Value: Equatable & DatabaseValue & DatabaseTestValue {
 
     // MARK: Values set
 

--- a/Sources/SafeFetching/Predicate/Declarations/StringKeyPredicateRightValue+DatabaseValue.swift
+++ b/Sources/SafeFetching/Predicate/Declarations/StringKeyPredicateRightValue+DatabaseValue.swift
@@ -3,7 +3,7 @@
 // Copyright © 2021-present Alexis Bridoux.
 // MIT license, see LICENSE file for details
 
-public extension Builders.StringKeyPathPredicateRightValue where Value: DatabaseValue & Equatable {
+public extension Builders.StringKeyPathPredicateRightValue where Value: Equatable & DatabaseTestValue {
 
     /// - important: Should be used only with database values that are converted from/to a primitive value
     static func isIn(_ array: [Value]) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> {

--- a/Sources/SafeFetching/Predicate/Declarations/StringKeyPredicateRightValue+OptionSet.swift
+++ b/Sources/SafeFetching/Predicate/Declarations/StringKeyPredicateRightValue+OptionSet.swift
@@ -7,17 +7,15 @@ public extension Builders.StringKeyPathPredicateRightValue where Value: OptionSe
 
     /// - important: Should be used only with options set types that are converted from/to a primitive value
     static func intersects(_ value: Value) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, Value> {
-        .init {
-            .init(keyPathString: $0.key, value: value) { "\($0) & %@ == \($0)" }
-        argumentsOrder: { [$0, value.rawValue, $0] }
+        .init { keyPathString in
+            .init(keyPathString: keyPathString.key) { "\($0) & \(value.testValue) == \($0)" }
         }
     }
 
     /// - important: Should be used only with options set types that are converted from/to a primitive value
     static func doesNotIntersect(_ value: Value) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, Value> {
-        .init {
-            .init(keyPathString: $0.key, value: value) { "\($0) & %@ != \($0)" }
-            argumentsOrder: { [$0, value.rawValue, $0] }
+        .init { keyPathString in
+            .init(keyPathString: keyPathString.key) { "\($0) & \(value.testValue) != \($0)" }
         }
     }
 }
@@ -27,18 +25,16 @@ public extension Builders.StringKeyPathPredicateRightValue {
     /// - important: Should be used only with options set types that are converted from/to a primitive value
     static func intersects<W: OptionSet & DatabaseTestValue>(_ value: W) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, Value>
     where Value == W?, W.RawValue: BinaryInteger {
-        .init {
-            .init(keyPathString: $0.key, value: value) { "\($0) & %@ == \($0)" }
-        argumentsOrder: { [$0, value.rawValue, $0] }
+        .init { keyPathString in
+            .init(keyPathString: keyPathString.key) { "\($0) & \(value.testValue) == \($0)" }
         }
     }
 
     /// - important: Should be used only with options set types that are converted from/to a primitive value
     static func doesNotIntersect<W: OptionSet & DatabaseTestValue>(_ value: W) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, Value>
     where Value == W?, W.RawValue: BinaryInteger {
-        .init {
-            .init(keyPathString: $0.key, value: value) { "\($0) & %@ != \($0)" }
-        argumentsOrder: { [$0, value.rawValue, $0] }
+        .init { keyPathString in
+            .init(keyPathString: keyPathString.key) { "\($0) & \(value.testValue) != \($0)" }
         }
     }
 }

--- a/Sources/SafeFetching/Predicate/Declarations/StringKeyPredicateRightValue+OptionSet.swift
+++ b/Sources/SafeFetching/Predicate/Declarations/StringKeyPredicateRightValue+OptionSet.swift
@@ -3,7 +3,7 @@
 // Copyright © 2021-present Alexis Bridoux.
 // MIT license, see LICENSE file for details
 
-public extension Builders.StringKeyPathPredicateRightValue where Value: OptionSet, Value.RawValue: BinaryInteger {
+public extension Builders.StringKeyPathPredicateRightValue where Value: OptionSet, Value.RawValue: BinaryInteger, Value: DatabaseTestValue {
 
     /// - important: Should be used only with options set types that are converted from/to a primitive value
     static func intersects(_ value: Value) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, Value> {
@@ -25,7 +25,7 @@ public extension Builders.StringKeyPathPredicateRightValue where Value: OptionSe
 public extension Builders.StringKeyPathPredicateRightValue {
 
     /// - important: Should be used only with options set types that are converted from/to a primitive value
-    static func intersects<W: OptionSet>(_ value: W) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, Value>
+    static func intersects<W: OptionSet & DatabaseTestValue>(_ value: W) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, Value>
     where Value == W?, W.RawValue: BinaryInteger {
         .init {
             .init(keyPathString: $0.key, value: value) { "\($0) & %@ == \($0)" }
@@ -34,7 +34,7 @@ public extension Builders.StringKeyPathPredicateRightValue {
     }
 
     /// - important: Should be used only with options set types that are converted from/to a primitive value
-    static func doesNotIntersect<W: OptionSet>(_ value: W) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, Value>
+    static func doesNotIntersect<W: OptionSet & DatabaseTestValue>(_ value: W) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, Value>
     where Value == W?, W.RawValue: BinaryInteger {
         .init {
             .init(keyPathString: $0.key, value: value) { "\($0) & %@ != \($0)" }

--- a/Sources/SafeFetching/Predicate/Declarations/StringKeyPredicateRightValue+RawRepresentable.swift
+++ b/Sources/SafeFetching/Predicate/Declarations/StringKeyPredicateRightValue+RawRepresentable.swift
@@ -3,62 +3,62 @@
 // Copyright © 2021-present Alexis Bridoux.
 // MIT license, see LICENSE file for details
 
-public extension Builders.StringKeyPathPredicateRightValue where Value: RawRepresentable {
-
-    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
-    ///
-    /// - note: For an option set, prefer the operation ``intersects(_:)-4pwbt``
-    static func isIn(_ array: [Value]) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> {
-        .init { .init(keyPathString: $0.key, operatorString: "IN", value: array.map(\.rawValue)) }
-    }
-
-    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
-    ///
-    /// - note: For an option set, prefer the operation ``doesNotIntersect(_:)-5mwmt``
-    static func isNotIn(_ array: [Value]) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> {
-        .init { .init(keyPathString: $0.key, operatorString: "IN", value: array.map(\.rawValue), isInverted: true) }
-    }
-
-    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
-    ///
-    /// - note: For an option set, prefer the operation ``intersects(_:)-4pwbt``
-    static func isIn(_ values: Value...) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> {
-        isIn(values)
-    }
-
-    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
-    ///
-    /// - note: For an option set, prefer the operation ``doesNotIntersect(_:)-5mwmt``
-    static func isNotIn(_ values: Value...) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> {
-        isNotIn(values)
-    }
-}
-
-public extension Builders.StringKeyPathPredicateRightValue {
-
-    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
-    ///
-    /// - note: For an option set, prefer the operation ``intersects(_:)-98s3b``
-    static func isIn<W: RawRepresentable>(_ array: [W]) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> where Value == W? {
-        .init { .init(keyPathString: $0.key, operatorString: "IN", value: array.map(\.rawValue)) }
-    }
-
-    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
-    ///
-    /// - note: For an option set, prefer the operation ``doesNotIntersect(_:)-4abl9``
-    static func isNotIn<W: RawRepresentable>(_ array: [W]) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> where Value == W? {
-        .init { .init(keyPathString: $0.key, operatorString: "IN", value: array.map(\.rawValue), isInverted: true) }
-    }
-
-    /// - note: For an option set, prefer the operation ``intersects(_:)-98s3b``
-    static func isIn<W: RawRepresentable>(_ values: W...) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> where Value == W? {
-        isIn(values)
-    }
-
-    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
-    ///
-    /// - note: For an option set, prefer the operation ``doesNotIntersect(_:)-4abl9``
-    static func isNotIn<W: RawRepresentable>(_ values: W...) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> where Value == W? {
-        .isNotIn(values)
-    }
-}
+//public extension Builders.StringKeyPathPredicateRightValue where Value: RawRepresentable, Value: DatabaseTestValue {
+//
+//    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
+//    ///
+//    /// - note: For an option set, prefer the operation ``intersects(_:)-4pwbt``
+//    static func isIn(_ array: [Value]) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> {
+//        .init { .init(keyPathString: $0.key, operatorString: "IN", value: array.map(\.rawValue)) }
+//    }
+//
+//    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
+//    ///
+//    /// - note: For an option set, prefer the operation ``doesNotIntersect(_:)-5mwmt``
+//    static func isNotIn(_ array: [Value]) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> {
+//        .init { .init(keyPathString: $0.key, operatorString: "IN", value: array.map(\.rawValue), isInverted: true) }
+//    }
+//
+//    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
+//    ///
+//    /// - note: For an option set, prefer the operation ``intersects(_:)-4pwbt``
+//    static func isIn(_ values: Value...) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> {
+//        isIn(values)
+//    }
+//
+//    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
+//    ///
+//    /// - note: For an option set, prefer the operation ``doesNotIntersect(_:)-5mwmt``
+//    static func isNotIn(_ values: Value...) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> {
+//        isNotIn(values)
+//    }
+//}
+//
+//public extension Builders.StringKeyPathPredicateRightValue {
+//
+//    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
+//    ///
+//    /// - note: For an option set, prefer the operation ``intersects(_:)-98s3b``
+//    static func isIn<W: RawRepresentable>(_ array: [W]) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> where Value == W? {
+//        .init { .init(keyPathString: $0.key, operatorString: "IN", value: array.map(\.rawValue)) }
+//    }
+//
+//    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
+//    ///
+//    /// - note: For an option set, prefer the operation ``doesNotIntersect(_:)-4abl9``
+//    static func isNotIn<W: RawRepresentable>(_ array: [W]) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> where Value == W? {
+//        .init { .init(keyPathString: $0.key, operatorString: "IN", value: array.map(\.rawValue), isInverted: true) }
+//    }
+//
+//    /// - note: For an option set, prefer the operation ``intersects(_:)-98s3b``
+//    static func isIn<W: RawRepresentable>(_ values: W...) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> where Value == W? {
+//        isIn(values)
+//    }
+//
+//    /// - important: Should be used only with raw representable types that are converted from/to a primitive value
+//    ///
+//    /// - note: For an option set, prefer the operation ``doesNotIntersect(_:)-4abl9``
+//    static func isNotIn<W: RawRepresentable>(_ values: W...) -> Builders.StringKeyPathPredicateRightValue<Entity, Value, [Value]> where Value == W? {
+//        .isNotIn(values)
+//    }
+//}

--- a/Sources/SafeFetching/Predicate/Types/KeyPathPredicateRightValue.swift
+++ b/Sources/SafeFetching/Predicate/Types/KeyPathPredicateRightValue.swift
@@ -9,7 +9,7 @@ extension Builders {
 
     /// An operator and its right operand for a predicate, with no key path.
     public struct KeyPathPredicateRightValue<Entity: NSManagedObject, Value, TestValue> {
-        public typealias KeyPathPredicateExpression = (KeyPath<Entity, Value>) -> Predicate<Entity>
+        public typealias KeyPathPredicateExpression = (_ keyPath: KeyPath<Entity, Value>) -> Predicate<Entity>
 
         public let predicate: KeyPathPredicateExpression
 

--- a/Sources/SafeFetching/Predicate/Types/Predicate.swift
+++ b/Sources/SafeFetching/Predicate/Types/Predicate.swift
@@ -27,15 +27,14 @@ extension Builders {
 
 extension Builders.Predicate {
 
-    public convenience init<Value, TestValue>(
+    public convenience init<Value, TestValue: DatabaseTestValue>(
         keyPath: KeyPath<Entity, Value>,
         operatorString: String,
         value: TestValue,
         isInverted: Bool = false
     ) {
-        let value = value
         let formatter: Formatter = { "\(isInverted ? "NOT" : "") \($0) \(operatorString) \(Self.attributeSymbol)" }
-        let argumentsOrder: ArgumentsOrder = { [$0, value] }
+        let argumentsOrder: ArgumentsOrder = { [$0, value.testValue] }
 
         let arguments = argumentsOrder(keyPath.label)
         let format = formatter(Self.keyPathSymbol)
@@ -43,15 +42,14 @@ extension Builders.Predicate {
         self.init(nsValue: NSPredicate(format: format, argumentArray: arguments))
     }
 
-    public convenience init<Value, TestValue>(
+    public convenience init<Value, TestValue: DatabaseTestValue>(
         keyPath: KeyPath<Entity, Value>,
         value: TestValue, isInverted: Bool = false,
         formatter: @escaping Formatter,
         argumentsOrder: ArgumentsOrder? = nil
     ) {
-        let value = value
         let formatter = formatter
-        let argumentsOrder = argumentsOrder ?? { [$0, value] }
+        let argumentsOrder = argumentsOrder ?? { [$0, value.testValue] }
 
         let arguments = argumentsOrder(keyPath.label)
         let format = formatter(Self.keyPathSymbol)
@@ -64,15 +62,14 @@ extension Builders.Predicate {
 
 extension Builders.Predicate {
 
-    public convenience init<TestValue>(
+    public convenience init<TestValue: DatabaseTestValue>(
         keyPathString: String,
         operatorString: String,
         value: TestValue,
         isInverted: Bool = false
     ) {
-        let value = value
         let formatter: Formatter = { "\(isInverted ? "NOT" : "") \($0) \(operatorString) \(Self.attributeSymbol)" }
-        let argumentsOrder: ArgumentsOrder = { [$0, value] }
+        let argumentsOrder: ArgumentsOrder = { [$0, value.testValue] }
 
         let arguments = argumentsOrder(keyPathString)
         let format = formatter(Self.keyPathSymbol)
@@ -80,15 +77,14 @@ extension Builders.Predicate {
         self.init(nsValue: NSPredicate(format: format, argumentArray: arguments))
     }
 
-    public convenience init<TestValue>(
+    public convenience init<TestValue: DatabaseTestValue>(
         keyPathString: String,
         value: TestValue, isInverted: Bool = false,
         formatter: @escaping Formatter,
         argumentsOrder: ArgumentsOrder? = nil
     ) {
-        let value = value
         let formatter = formatter
-        let argumentsOrder = argumentsOrder ?? { [$0, value] }
+        let argumentsOrder = argumentsOrder ?? { [$0, value.testValue] }
 
         let arguments = argumentsOrder(keyPathString)
         let format = formatter(Self.keyPathSymbol)

--- a/Sources/SafeFetching/Predicate/Types/Predicate.swift
+++ b/Sources/SafeFetching/Predicate/Types/Predicate.swift
@@ -9,11 +9,7 @@ extension Builders {
 
     public class Predicate<Entity: NSManagedObject> {
 
-        public typealias Formatter = (String) -> String
-        public typealias ArgumentsOrder = (Any) -> [Any]
-
-        static var keyPathSymbol: String { "%K" }
-        static var attributeSymbol: String { "%@" }
+        public typealias Formatter = (_ keyPath: String) -> String
 
         public let nsValue: NSPredicate
 
@@ -33,28 +29,18 @@ extension Builders.Predicate {
         value: TestValue,
         isInverted: Bool = false
     ) {
-        let formatter: Formatter = { "\(isInverted ? "NOT" : "") \($0) \(operatorString) \(Self.attributeSymbol)" }
-        let argumentsOrder: ArgumentsOrder = { [$0, value.testValue] }
-
-        let arguments = argumentsOrder(keyPath.label)
-        let format = formatter(Self.keyPathSymbol)
-
-        self.init(nsValue: NSPredicate(format: format, argumentArray: arguments))
+        let format = "\(isInverted ? "NOT" : "") \(keyPath.label) \(operatorString) \(value.testValue)"
+        self.init(nsValue: NSPredicate(format: format))
     }
 
-    public convenience init<Value, TestValue: DatabaseTestValue>(
+    public convenience init<Value>(
         keyPath: KeyPath<Entity, Value>,
-        value: TestValue, isInverted: Bool = false,
-        formatter: @escaping Formatter,
-        argumentsOrder: ArgumentsOrder? = nil
+        isInverted: Bool = false,
+        formatter: @escaping Formatter
     ) {
-        let formatter = formatter
-        let argumentsOrder = argumentsOrder ?? { [$0, value.testValue] }
 
-        let arguments = argumentsOrder(keyPath.label)
-        let format = formatter(Self.keyPathSymbol)
-
-        self.init(nsValue: NSPredicate(format: format, argumentArray: arguments))
+        let format = formatter(keyPath.label)
+        self.init(nsValue: NSPredicate(format: format))
     }
 }
 
@@ -68,27 +54,17 @@ extension Builders.Predicate {
         value: TestValue,
         isInverted: Bool = false
     ) {
-        let formatter: Formatter = { "\(isInverted ? "NOT" : "") \($0) \(operatorString) \(Self.attributeSymbol)" }
-        let argumentsOrder: ArgumentsOrder = { [$0, value.testValue] }
-
-        let arguments = argumentsOrder(keyPathString)
-        let format = formatter(Self.keyPathSymbol)
-
-        self.init(nsValue: NSPredicate(format: format, argumentArray: arguments))
+        let format = "\(isInverted ? "NOT" : "") \(keyPathString) \(operatorString) \(value.testValue)"
+        self.init(nsValue: NSPredicate(format: format))
     }
 
-    public convenience init<TestValue: DatabaseTestValue>(
+    public convenience init(
         keyPathString: String,
-        value: TestValue, isInverted: Bool = false,
-        formatter: @escaping Formatter,
-        argumentsOrder: ArgumentsOrder? = nil
+        isInverted: Bool = false,
+        formatter: @escaping Formatter
     ) {
-        let formatter = formatter
-        let argumentsOrder = argumentsOrder ?? { [$0, value.testValue] }
 
-        let arguments = argumentsOrder(keyPathString)
-        let format = formatter(Self.keyPathSymbol)
-
-        self.init(nsValue: NSPredicate(format: format, argumentArray: arguments))
+        let format = formatter(keyPathString)
+        self.init(nsValue: NSPredicate(format: format))
     }
 }

--- a/Sources/SafeFetching/SafeFetching.docc/Articles/build-predicates.md
+++ b/Sources/SafeFetching/SafeFetching.docc/Articles/build-predicates.md
@@ -159,7 +159,7 @@ With an option set, it's advised to rather use the `intersects` predicates.
 With the colors now as an option set:
 
 ```swift
-enum Colors: OptionSet {
+struct Colors: OptionSet {
     let rawValue: Int
 
     static let red = StubOptionSet(rawValue: 1 << 0)
@@ -185,11 +185,9 @@ Note that
 predicate = .color * .intersects(.blue)
 ```
 
-is the same as
+is only the same as
 
 ```swift
 predicate = .color == .blue
 ```
-*only when the stored `color` is a single option*. 
-
-Thus **always prefer using the `intersects` operator.**
+*when the stored `color` is a single option*. 

--- a/Sources/SafeFetching/SafeFetching.docc/SafeFetching.md
+++ b/Sources/SafeFetching/SafeFetching.docc/SafeFetching.md
@@ -12,38 +12,53 @@ This library offers a DSL (Domain Specific Language) to build predicates and req
 
 - <doc:build-predicates>
 - ``Builders/Predicate``
-- ``Builders/CompoundPredicate``
-- ``Builders/KeyPathPredicateRightValue``
-- ``Builders/StringKeyPathPredicateRightValue``
 - ``DatabaseValue``
 - ``DatabaseValueIdentification``
+- ``DatabaseTestValue``
 
 ### Key path predicates
 
-- <doc:build-predicates>
-- ``&&(_:_:)``
-- ``__(_:_:)``
+Key paths predicate work with key paths that target a property exposed to Objective-C. For instance `@objc`  or `NSManaged`. To use properties that are automatically converted to be stored, use a ``StringKeyPath``.
+
+- ``Builders/KeyPathPredicateRightValue``
+- ``==(_:_:)-23gbz``
+- ``!=(_:_:)-sw2d``
+- ``_(_:_:)-6ignz``
+- ``_=(_:_:)-3bumn``
+- ``_(_:_:)-2o0zw``
+- ``_=(_:_:)-7tt3x``
 
 ### Key path advanced predicates
 
-- <doc:build-predicates>
+Advanced predicates like string comparison ``Builders/KeyPathPredicateRightValue/hasPrefix(_:)-3w8p3`` or membership ``Builders/KeyPathPredicateRightValue/isIn(_:)-8lnwn`` can be used with the special operator `*`.
+
 - ``*(_:_:)-9ve4y``
 
 ### String key path comparison
 
-- <doc:build-predicates>
+``StringKeyPath`` allow to define a property name with the entity and value types when the property is not a `NSManaged` one but is transformed to be stored as a database value (like storing the `rawValue` of a `RawRepresentable`).
+
 - ``StringKeyPath``
-- ``==(_:_:)-3tl1a``
-- ``!=(_:_:)-53mz``
-- ``_(_:_:)-2t2xr``
-- ``_=(_:_:)-8camq``
-- ``_(_:_:)-87xrg``
-- ``_=(_:_:)-46p18``
+- ``Builders/StringKeyPathPredicateRightValue``
+- ``==(_:_:)-91q9n``
+- ``!=(_:_:)-4s1nt``
+- ``_(_:_:)-4t33p``
+- ``_=(_:_:)-7schv``
+- ``_(_:_:)-756zh``
+- ``_=(_:_:)-627jw``
+
 
 ### String key paths advanced predicates
 
-- <doc:build-predicates>
+Advanced predicates like membership ``Builders/StringKeyPathPredicateRightValue/isIn(_:)-2ewm2`` can be used with the special operator `*`.
+
 - ``*(_:_:)-2b678``
+
+### Compound predicate
+
+- ``Builders/CompoundPredicate``
+- ``&&(_:_:)``
+- ``__(_:_:)``
 
 ### Build requests
 

--- a/Tests/SafeFetchingTests/BooleanPredicateBuilderTests.swift
+++ b/Tests/SafeFetchingTests/BooleanPredicateBuilderTests.swift
@@ -15,6 +15,7 @@ final class BooleanPredicateTests: XCTestCase {
         testNSFormat(predicate: \.score >= 10, expecting: "score >= 10")
         testNSFormat(predicate: \.score < 10, expecting: "score < 10")
         testNSFormat(predicate: \.score <= 10, expecting: "score <= 10")
+        testNSFormat(predicate: \.property == nil, expecting: "property == nil")
     }
 
     func testString() {
@@ -125,7 +126,7 @@ extension BooleanPredicateTests {
 
 extension BooleanPredicateTests {
 
-    enum StubEnum: Int, Comparable {
+    enum StubEnum: Int, Comparable, DatabaseTestValue {
         case foo = 1
         case bar = 2
 
@@ -153,7 +154,7 @@ extension StringKeyPath where Entity == BooleanPredicateTests.StubEntity, Value 
 
 extension BooleanPredicateTests {
 
-    struct StubOptionSet: OptionSet {
+    struct StubOptionSet: OptionSet, DatabaseTestValue {
         let rawValue: Int
 
         static let foo = StubOptionSet(rawValue: 1 << 0)

--- a/Tests/SafeFetchingTests/BooleanPredicateBuilderTests.swift
+++ b/Tests/SafeFetchingTests/BooleanPredicateBuilderTests.swift
@@ -69,7 +69,7 @@ final class BooleanPredicateTests: XCTestCase {
         testNSFormat(\.score, .isIn(1...10), expecting: #"score BETWEEN {1, 10}"#)
         testNSFormat(\.score, .isNotIn(1...10), expecting: #"NOT score BETWEEN {1, 10}"#)
         testNSFormat(\.score, .isIn(1..<10.5), expecting: #"1 <= score AND score < 10.5"#)
-        testNSFormat(\.score, .isNotIn(1..<10.5), expecting: #"1 > score OR score >= 10.5"#)
+        testNSFormat(\.score, .isNotIn(1..<10.5), expecting: #"score < 1 OR score >= 10.5"#)
     }
 }
 

--- a/Tests/SafeFetchingTests/RequestBuilderTests.swift
+++ b/Tests/SafeFetchingTests/RequestBuilderTests.swift
@@ -97,15 +97,6 @@ final class RequestBuilderTests: XCTestCase {
 
         XCTAssertTrue(request.returnsDistinctResults)
     }
-
-    func testStringKeyPath_databaseValue() {
-        let request = StubEntity.request()
-            .all()
-            .where(.stubDatabaseValue == 10)
-            .nsValue
-
-        XCTAssertTrue(request.returnsDistinctResults)
-    }
 }
 
 // MARK: - Models


### PR DESCRIPTION
Protocol to allow values of several types that offers a string representation to be used as test value in a predicate. Reworked the `Predicate` init to use that and be more flexible.